### PR TITLE
feat(ticketing): update table on submit; persist via Firestore; widen…

### DIFF
--- a/volunteer-app/src/Ticketing/Ticketing.css
+++ b/volunteer-app/src/Ticketing/Ticketing.css
@@ -240,3 +240,40 @@ select {
             flex-direction: column;
         }
   
+        
+.full-page,
+.ticket-div {
+  max-width: 1200px;      
+  width: 100%;
+  margin: 0 auto;         
+}
+
+.ticket-table {
+  width: 100% !important;            
+  max-width: none !important;        
+}
+
+.ticket-table table {
+  width: 100% !important;            
+  table-layout: auto;                
+  border-collapse: collapse;
+}
+
+.ticket-table th,
+.ticket-table td {
+  padding: 8px 12px;                
+  vertical-align: top;
+  word-break: break-word;         
+}
+
+.table-append {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;                  
+}
+.main-content {
+  padding: 16px;
+}
+

--- a/volunteer-app/src/Ticketing/Ticketing.js
+++ b/volunteer-app/src/Ticketing/Ticketing.js
@@ -1,262 +1,335 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import NavBarAdmin from "../Pages/navBarAdmin";
-import "./Ticketing.css"
+import "./Ticketing.css";
 
+import { db } from "../firebase";
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
 
-const Ticketing = (props)=>{
-    const defaultData = {priority:"",due_date:"",recipient:"",description:"",type:"",team:"",title:""};
-    const[formData,setFormData]=useState({...defaultData});
-    const[ticketNumber,setTicketNumber]=useState(1);
-    const[errors,setErrors]=useState({});
-    const[message,setMessage]=useState("");
-    const handleChange = (event)=>{
-        setMessage('');
-        const {name, value} = event.target;
-        setFormData({...formData,[name]:value});
-        if(value === ""){
-            setErrors({...errors,[name]:true})
-        }else{
-           setErrors({...errors,[name]:false}) 
-        }
+const Ticketing = () => {
+  const defaultData = {
+    priority: "",
+    due_date: "",
+    recipient: "",
+    description: "",
+    type: "",
+    team: "",
+    title: "",
+  };
+
+  const [formData, setFormData] = useState({ ...defaultData });
+  const [errors, setErrors] = useState({});
+  const [message, setMessage] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Table rows come from Firestore in real time
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    const q = query(collection(db, "tickets"), orderBy("createdAt", "desc"));
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const data = snap.docs.map((d) => {
+          const v = d.data();
+          return {
+            id: d.id,
+            due_date: v.due_date || "",
+            client: v.recipient || v.team || "—",
+            request: v.description || v.title || "",
+            statusClass: v.statusClass || "open",
+            statusLabel: v.statusLabel || "Open",
+            priority: v.priority || "—",
+          };
+        });
+        setRows(data);
+      },
+      (err) => {
+        console.error("Firestore listen error:", err);
+        setMessage("Cannot read from Firebase (permission or config issue).");
+      }
+    );
+    return () => unsub();
+  }, []);
+
+  const handleChange = (e) => {
+    setMessage("");
+    const { name, value } = e.target;
+    setFormData((p) => ({ ...p, [name]: value }));
+    setErrors((p) => ({ ...p, [name]: value === "" }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    // simple required validation
+    let hasErrors = false;
+    const copy = { ...errors };
+    Object.keys(formData).forEach((k) => {
+      if (formData[k] === "") {
+        copy[k] = true;
+        hasErrors = true;
+      }
+    });
+    if (hasErrors) {
+      setErrors(copy);
+      return;
     }
-    const handleSubmit = ()=>{
-        let num = 0;
-        const errorCopy = {...errors};
-        Object.keys({...formData}).forEach(element=>{
-            if(formData[element] === ""){
-                errorCopy[element]= true;
-                num++;
-            }else{
-                errorCopy[element] = false;
-            }
-        })
-        if(num > 0){
-            setErrors(errorCopy);
-            return;
-        }
-        setMessage("Please wait we are submitting your ticket");
-        setTimeout(function(){
-            setMessage("Your ticket submitted successfully and, ticket number:#"+(ticketNumber));
-            setFormData(defaultData);
-            setTicketNumber(ticketNumber+1);
-        },4000)
 
+    setSaving(true);
+    setMessage("Please wait we are submitting your ticket");
+
+    try {
+      await addDoc(collection(db, "tickets"), {
+        title: formData.title,
+        team: formData.team,
+        type: formData.type,
+        description: formData.description,
+        recipient: formData.recipient,
+        due_date: formData.due_date,
+        priority: formData.priority,
+        statusClass: "open",
+        statusLabel: "Open",
+        createdAt: serverTimestamp(),
+      });
+
+      setMessage("Your ticket submitted successfully.");
+      setFormData(defaultData);
+    } catch (err) {
+      console.error("Firestore write error:", err);
+      setMessage("There was a problem saving to Firebase (permission/config).");
+    } finally {
+      setSaving(false);
     }
-    return(
-        <>
-        <NavBarAdmin/>
- <div className="main-content">
+  };
+
+  return (
+    <>
+      <NavBarAdmin />
+      <div className="main-content">
         <div className="full-page">
-           <div className="ticket-div">
-      <div className="top-bar">
-        <div className="ticket-filter">
-          <select name="filter" id="filter">
-            <option selected>Filter By: (Dropdown)</option>
-            <option value="due date">Due Date</option>
-            <option value="client">Client</option>
-            <option value="request">Request</option>
-            <option value="status">Status</option>
-            <option value="priority">Priority</option>
-          </select>
-        </div>
-        <div className="button-group">
-          <button className="button">
-            <img
-              src="https://img.icons8.com/ios-filled/50/000000/edit--v1.png"
-              alt="Edit Icon"
-            />
-            Edit Ticket
-          </button>
-          <button className="button">
-            <img
-              src="https://img.icons8.com/ios-filled/50/000000/edit--v1.png"
-              alt="Edit Icon"
-            />
-            New Ticket
-          </button>
+          <div className="ticket-div">
+            <div className="top-bar">
+              <div className="ticket-filter">
+                <select name="filter" id="filter" defaultValue="">
+                  <option value="">Filter By: (Dropdown)</option>
+                  <option value="due date">Due Date</option>
+                  <option value="client">Client</option>
+                  <option value="request">Request</option>
+                  <option value="status">Status</option>
+                  <option value="priority">Priority</option>
+                </select>
+              </div>
+              <div className="button-group">
+                <button className="button">
+                  <img
+                    src="https://img.icons8.com/ios-filled/50/000000/edit--v1.png"
+                    alt="Edit Icon"
+                  />
+                  Edit Ticket
+                </button>
+                <button className="button">
+                  <img
+                    src="https://img.icons8.com/ios-filled/50/000000/edit--v1.png"
+                    alt="Edit Icon"
+                  />
+                  New Ticket
+                </button>
+              </div>
+            </div>
+
+            <div className="ticket-table">
+              <div className="table-append">
+                <span>
+                  Show entries:
+                  <select className="input" defaultValue="50">
+                    <option value="50" disabled>
+                      50
+                    </option>
+                  </select>
+                </span>
+                <span>
+                  Search:
+                  <input type="text" className="input" />
+                </span>
+              </div>
+
+              <table>
+                <colgroup>
+                  <col />
+                  <col />
+                  <col />
+                  <col />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th>Due Date</th>
+                    <th>Client</th>
+                    <th>Request</th>
+                    <th>Status</th>
+                    <th>Priority</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => (
+                    <tr key={r.id}>
+                      <td>{r.due_date}</td>
+                      <td>{r.client}</td>
+                      <td>{r.request}</td>
+                      <td>
+                        <span className={`status ${r.statusClass}`}>
+                          {r.statusLabel}
+                        </span>
+                      </td>
+                      <td>{r.priority}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              <div className="table-append">
+                <p id="entryText">
+                  Showing {rows.length} {rows.length === 1 ? "entry" : "entries"}
+                </p>
+                <span className="pagination">
+                  <button>Previous</button>
+                  <span className="page-number" id="pageNumber">
+                    Page 1
+                  </span>
+                  <button>Next</button>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="container">
+            <h1>Ticket Submission Form</h1>
+            <form onSubmit={handleSubmit} method="post">
+              <div className="form-group">
+                <label htmlFor="title">Title of Ticket</label>
+                <input
+                  id="title"
+                  name="title"
+                  placeholder="Enter title"
+                  value={formData.title}
+                  onChange={handleChange}
+                />
+                {errors.title && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="team">Team Name</label>
+                <select
+                  id="team"
+                  name="team"
+                  value={formData.team}
+                  onChange={handleChange}
+                >
+                  <option value="">Select team</option>
+                  <option value="team-a">Volunteer App</option>
+                </select>
+                {errors.team && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="type">Type</label>
+                <input
+                  id="type"
+                  name="type"
+                  placeholder="Enter type of ticket"
+                  value={formData.type}
+                  onChange={handleChange}
+                />
+                {errors.type && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="description">Description</label>
+                <textarea
+                  id="description"
+                  name="description"
+                  rows="4"
+                  placeholder="Enter description"
+                  value={formData.description}
+                  onChange={handleChange}
+                />
+                {errors.description && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="recipient">
+                  Recipient Information (Email/DiscordID/Username)
+                </label>
+                <input
+                  id="recipient"
+                  name="recipient"
+                  placeholder="Enter recipient information"
+                  value={formData.recipient}
+                  onChange={handleChange}
+                />
+                {errors.recipient && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="due-date">Due Date</label>
+                <input
+                  type="date"
+                  id="due-date"
+                  name="due_date"
+                  value={formData.due_date}
+                  onChange={handleChange}
+                />
+                {errors.due_date && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="priority">Priority</label>
+                <select
+                  id="priority"
+                  name="priority"
+                  value={formData.priority}
+                  onChange={handleChange}
+                >
+                  <option value="">Select</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+                {errors.priority && (
+                  <p className="error">Please fill required field</p>
+                )}
+              </div>
+
+              <button type="submit" disabled={saving}>
+                {saving ? "Submitting..." : "Submit"}
+              </button>
+              {message && <p className="success-message">{message}</p>}
+            </form>
+          </div>
         </div>
       </div>
-      <div className="ticket-table">
-        <div className="table-append">
-          <span>
-            Show entries:
-            <select className="input">
-              <option value="50" selected disabled>50</option>
-            </select>
-          </span>
-          <span>
-            Search:
-            <input type="text" className="input" />
-          </span>
-        </div>
-        <table>
-          <colgroup>
-            <col />
-            <col  />
-            <col  />
-            <col />
-            <col />
-          </colgroup>
-          <tr>
-            <th>Due Date</th>
-            <th>Client</th>
-            <th>Request</th>
-            <th>Status</th>
-            <th>Priority</th>
-          </tr>
-          <tr>
-            <td>12/31/2020</td>
-            <td>Jeff Smith</td>
-            <td>
-              Lorem ipsum dolor sit amet consectetur adipiscing elit.
-              Consectetur adipiscing elit quisque faucibus ex sapien vitae. Ex
-              sapien vitae pellentesque sem placerat in id. Placerat in id
-              cursus mi pretium tellus duis. Pretium tellus duis convallis
-              tempus leo eu aenean.
-            </td>
-            <td><span className="status open">Open</span></td>
-            <td>4</td>
-          </tr>
-          <tr>
-            <td>12/28/2020</td>
-            <td>Maria Jones</td>
-            <td>
-              Lorem ipsum dolor sit amet consectetur adipiscing elit. Sit amet
-              consectetur adipiscing elit quisque faucibus ex. Adipiscing elit
-              quisque faucibus ex sapien vitae pellentesque.
-            </td>
-            <td><span className="status closed">Closed</span></td>
-            <td>2</td>
-          </tr>
-          <tr>
-            <td>12/23/2020</td>
-            <td>John Cobaine</td>
-            <td>
-              Lorem ipsum dolor sit amet consectetur adipiscing elit quisque
-              faucibus ex sapien vitae pellentesque sem placerat in id cursus mi
-              pretium tellus duis convallis tempus leo eu aenean sed diam.
-            </td>
-            <td><span className="status paused">Paused</span></td>
-            <td>3</td>
-          </tr>
-          <tr>
-            <td>11/27/2020</td>
-            <td>Steve Buffet</td>
-            <td>Test OK</td>
-            <td><span className="status deleted">Deleted</span></td>
-            <td>1</td>
-          </tr>
-        </table>
-        <div className="table-append">
-          <p id="entryText">Showing 1 to 4 of 4 entries</p>
-          <span className="pagination">
-            <button
-              
-            >
-              Previous
-            </button>
-            <span className="page-number" id="pageNumber">Page 1</span>
-            <button
-              
-            >
-              Next
-            </button>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div className="container">
-      <h1>Ticket Submission Form</h1>
-      <form action="#" method="post">
-        <div className="form-group">
-          <label for="title">Title of Ticket</label>
-          <input
-            type="text"
-            id="title"
-            name="title"
-            placeholder="Enter title"
-            value={formData?.title}
-            onChange={handleChange}
-          />
-          {errors?.title && <p className="error">Please fill required field</p>}
-        </div>
+    </>
+  );
+};
 
-        <div className="form-group">
-          <label for="team">Team Name</label>
-          <select id="team" name="team" value={formData?.team} onChange={handleChange}>
-            <option value="">Select team</option>
-            <option value="team-a">Volunteer App</option>
-          </select>
-          {errors?.team && <p className="error">Please fill required field</p>}
-        </div>
-
-        <div className="form-group">
-          <label for="type">Type</label>
-          <input
-            type="text"
-            id="type"
-            name="type"
-            placeholder="Enter type of ticket"
-            value={formData?.type}
-            onChange={handleChange}
-          />
-           {errors?.type && <p className="error">Please fill required field</p>}
-        </div>
-
-        <div className="form-group">
-          <label for="description">Description</label>
-          <textarea
-            id="description"
-            name="description"
-            rows="4"
-            placeholder="Enter description"
-            value={formData?.description}
-            onChange={handleChange}
-          ></textarea>
-           {errors?.description && <p className="error">Please fill required field</p>}
-        </div>
-
-        <div className="form-group">
-          <label for="recipient"
-            >Recipient Information (Email/DiscordID/Username)</label
-          >
-          <input
-            type="text"
-            id="recipient"
-            name="recipient"
-            placeholder="Enter recipient information"
-            value={formData?.recipient}
-            onChange={handleChange}
-          />
-          {errors?.recipient && <p className="error">Please fill required field</p>}
-        </div>
-
-        <div className="form-group">
-          <label for="due-date">Due Date</label>
-          <input type="date" id="due-date" name="due_date"   value={formData?.due_date}
-            onChange={handleChange}/>
-          {errors?.due_date && <p className="error">Please fill required field</p>}
-        </div>
-
-        <div className="form-group">
-          <label for="priority">Priority</label>
-          <select id="priority" name="priority" value={formData?.priority}
-            onChange={handleChange}>
-                <option value="">Select</option>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-          </select>
-          {errors?.priority && <p className="error">Please fill required field</p>}
-        </div>
-
-        <button type="button" onClick={handleSubmit}>Submit</button>
-        {message !== "" && <p className="success-message">{message}</p>}
-      </form>
-    </div>
-        </div>
-        </div>
-        </>
-    )
-}
 export default Ticketing;

--- a/volunteer-app/src/firebase.js
+++ b/volunteer-app/src/firebase.js
@@ -1,20 +1,17 @@
-// Import the functions you need from the SDKs you need
+// src/firebase.js
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import { getFirestore } from "firebase/firestore";
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+// Your project's config (this is fine to keep in client code)
 const firebaseConfig = {
-    apiKey: "AIzaSyAuuq0i6-DITTNOFGzut3hy7ncsHgPj8bo",
-    authDomain: "stem-e-volunteer-app.firebaseapp.com",
-    projectId: "stem-e-volunteer-app",
-    storageBucket: "stem-e-volunteer-app.appspot.com",
-    messagingSenderId: "238931221133",
-    appId: "1:238931221133:web:00e64c3b8b9211f0b720c4",
-    measurementId: "G-6FEZM656MH"
+  apiKey: "AIzaSyAuuq0i6-DITTNOFGzut3hy7ncsHgPj8bo",
+  authDomain: "stem-e-volunteer-app.firebaseapp.com",
+  projectId: "stem-e-volunteer-app",
+  storageBucket: "stem-e-volunteer-app.appspot.com",
+  messagingSenderId: "238931221133",
+  appId: "1:238931221133:web:00e64c3b8b9211f0b720c4",
+  measurementId: "G-6FEZM656MH"
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);


### PR DESCRIPTION
- Writes tickets to Firestore collection `tickets` (fields: title, team, type, description, recipient, due_date, priority, statusClass, statusLabel, createdAt=serverTimestamp).
- Live `onSnapshot` query ordered by `createdAt` desc to render table.
- CSS overrides at bottom of Ticketing.css to expand table width on desktop.

Test steps:
1) npm start → open /ticketing
2) Submit a ticket
3) Row appears instantly (realtime), persists on refresh
4) Confirm doc in Firebase console under Firestore → `tickets`
